### PR TITLE
Fix upload PyPI error by specifying hatchling version

### DIFF
--- a/bindings/python/lyric-component-ts-transpiling/pyproject.toml
+++ b/bindings/python/lyric-component-ts-transpiling/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">= 3.10"
 
 [build-system]
 requires = [
-    "hatchling",
+    "hatchling==1.26.3",
 ]
 build-backend = "hatchling.build"
 

--- a/bindings/python/lyric-js-worker/pyproject.toml
+++ b/bindings/python/lyric-js-worker/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">= 3.8"
 
 [build-system]
 requires = [
-    "hatchling",
+    "hatchling==1.26.3",
 ]
 build-backend = "hatchling.build"
 

--- a/bindings/python/lyric-py-worker/pyproject.toml
+++ b/bindings/python/lyric-py-worker/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">= 3.8"
 
 [build-system]
 requires = [
-    "hatchling",
+    "hatchling==1.26.3",
 ]
 build-backend = "hatchling.build"
 

--- a/bindings/python/lyric-task/pyproject.toml
+++ b/bindings/python/lyric-task/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">= 3.8"
 
 [build-system]
 requires = [
-    "hatchling",
+    "hatchling==1.26.3",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
Update the hatchling dependency to version 1.26.3 to resolve issues with uploading to PyPI.