### PR TITLE
docs: Add build python worker doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ The following diagram illustrates the architecture of Lyric:
 - [Notebook-Sandbox Execution](examples/notebook/lyric_sandbox_verification.ipynb): A Jupyter notebook demonstrating how to use Lyric to execute Python and JavaScript code in a sandboxed environment.
 
 
+## Development
+
+If you want to build your own worker, you can see [How to Add Your Dependencies](bindings/python/lyric-py-worker/README.md#how-to-add-your-dependencies) 
+
 ## Community Integrations
 
 - [DB-GPT](https://github.com/eosphoros-ai/DB-GPT) AI Native Data App Development framework with AWEL(Agentic Workflow Expression Language) and Agents

--- a/bindings/python/lyric-py-worker/README.md
+++ b/bindings/python/lyric-py-worker/README.md
@@ -9,3 +9,49 @@ It allows you to run your python code in a wasm environment.
 ```bash
 pip install lyric-py-worker
 ```
+
+## How To Add Your Dependencies
+
+1. You can add your dependencies to the `app-requrements.txt` file.
+
+```bash
+echo "chardet" >> app-requirements.txt
+```
+
+2. Import the dependencies `src/worker.py`
+
+Modify the `src/worker.py` file to import your dependencies.
+
+```python
+import asyncio
+# ...
+# Import your dependencies at the top of the file
+import chardet
+# ...
+import shortuuid
+from lyric_task.std import *
+
+```
+
+3. Build the worker
+
+```bash
+make build
+```
+
+After building the worker, you can see the wheel file in the `../dist` directory.
+
+```bash
+ls ../dist/lyric_py_worker-*.whl
+../dist/lyric_py_worker-0.1.7rc0-py3-none-any.whl
+```
+The output may be like the above.
+
+4. Install the worker
+
+You can install your worker using the following command.
+
+```bash
+pip install --force-reinstall lyric_py_worker-0.1.7rc0-py3-none-any.whl
+```
+Make sure to replace the wheel file name with the one you have and the path to the wheel file.


### PR DESCRIPTION
Include instructions on how to add dependencies and build the Python worker in the documentation.

Closes #13 